### PR TITLE
Fix incrrect header guards.

### DIFF
--- a/genogroup.h
+++ b/genogroup.h
@@ -11,7 +11,7 @@
 //////////////////////////////////////////////////////////////////
 
 
-#ifndef __GENOGROUP_H_
+#ifndef __GENOGROUP_H__
 #define __GENOGROUP_H__
 
 

--- a/haplowindow.h
+++ b/haplowindow.h
@@ -10,7 +10,7 @@
 //////////////////////////////////////////////////////////////////
 
 
-#ifndef __HAPWINDOW_H_
+#ifndef __HAPWINDOW_H__
 #define __HAPWINDOW_H__
 
 class HaploPhase;

--- a/phase.h
+++ b/phase.h
@@ -11,7 +11,7 @@
 //////////////////////////////////////////////////////////////////
 
 
-#ifndef __HAPPHASE_H_
+#ifndef __HAPPHASE_H__
 #define __HAPPHASE_H__
 
 class HaploWindow;


### PR DESCRIPTION
This fixes Clang warning:
./phase.h:14:9: warning: '__HAPPHASE_H_' is used as a header guard here, followed by #define of a different macro [-Wheader-guard] ./phase.h:15:9: note: '__HAPPHASE_H__' is defined here; did you mean '__HAPPHASE_H_'?